### PR TITLE
Shape inference and show input/output shape of specific node operator type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A tool to show ONNX model summary like torchinfo
 ## Test
 `python3 -m pytest -v`
 
-Use model from [ONNX Model Zoo](https://github.com/onnx/models/tree/main) to test.
+Use model(resnet18_Opset16.onnx) from [ONNX Model Zoo](https://github.com/onnx/models/tree/main) to test.
 
 ## Docker
 * Run `docker build -t onnxinfo -f docker/Dockerfile .` first.

--- a/include/AttrInfo.hpp
+++ b/include/AttrInfo.hpp
@@ -5,21 +5,39 @@
 
 struct AttrInfo_Conv {
     std::vector<int64_t> kernel_shape; // got from Weight
-    std::vector<int64_t> strides = {1, 1, 1}; // default 1
-    std::vector<int64_t> pads = {0, 0, 0, 0, 0, 0}; // default 0
-    std::vector<int64_t> dilations = {1, 1, 1}; // default 1
+    std::vector<int64_t> strides; // default 1
+    std::vector<int64_t> pads; // default 0
+    std::vector<int64_t> dilations; // default 1
 
     int64_t group = 1; // not used now
+
+    void set_default_attr(size_t shape_len) {
+        for (size_t i = 0; i < shape_len - 2; ++i) {
+            strides.emplace_back(1);
+            pads.emplace_back(0);
+            pads.emplace_back(0);
+            dilations.emplace_back(1);
+        }
+    }
 };
 
 struct AttrInfo_MaxPool {
     std::vector<int64_t> kernel_shape;
-    std::vector<int64_t> strides = {1, 1, 1}; // default 1
-    std::vector<int64_t> pads = {0, 0, 0, 0, 0, 0}; // default 0
-    std::vector<int64_t> dilations = {1, 1, 1}; // default 1
+    std::vector<int64_t> strides; // default 1
+    std::vector<int64_t> pads; // default 0
+    std::vector<int64_t> dilations; // default 1
 
     int64_t ceil_mode = 0; // not used now
     int64_t storage_order = 0; // not used now
+
+    void set_default_attr(size_t shape_len) {
+        for (size_t i = 0; i < shape_len - 2; ++i) {
+            strides.emplace_back(1);
+            pads.emplace_back(0);
+            pads.emplace_back(0);
+            dilations.emplace_back(1);
+        }
+    }
 };
 
 struct AttrInfo_Gemm {

--- a/include/AttrInfo.hpp
+++ b/include/AttrInfo.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+#include "onnx.proto3.pb.h"
+
+struct AttrInfo_Conv {
+    std::vector<int64_t> kernel_shape; // got from Weight
+    std::vector<int64_t> strides = {1, 1, 1}; // default 1
+    std::vector<int64_t> pads = {0, 0, 0, 0, 0, 0}; // default 0
+    std::vector<int64_t> dilations = {1, 1, 1}; // default 1
+
+    int64_t group = 1; // not used now
+};
+
+struct AttrInfo_MaxPool {
+    std::vector<int64_t> kernel_shape;
+    std::vector<int64_t> strides = {1, 1, 1}; // default 1
+    std::vector<int64_t> pads = {0, 0, 0, 0, 0, 0}; // default 0
+    std::vector<int64_t> dilations = {1, 1, 1}; // default 1
+
+    int64_t ceil_mode = 0; // not used now
+    int64_t storage_order = 0; // not used now
+};
+
+struct AttrInfo_Gemm {
+    bool transA = false;
+    bool transB = false;
+};

--- a/include/InferShape.hpp
+++ b/include/InferShape.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <unordered_map>
+#include "onnx.proto3.pb.h"
+#include "AttrInfo.hpp"
+
+#define INDENT 30
+
+class InferShapeImpl {
+public:
+    InferShapeImpl() = default;
+    InferShapeImpl(const onnx::GraphProto &in_graph) : graph(in_graph) {}
+
+    ~InferShapeImpl() = default;
+
+    void set_io_iniz_shape_to_map();
+    void infer_shapes();
+    void print_summary();
+
+    std::unordered_map<std::string, std::vector<int64_t>> get_ndname_to_shape() {
+        return this->ndname_to_shape;
+    }
+
+private:
+    onnx::GraphProto graph;
+    std::unordered_map<std::string, std::vector<int64_t>> ndname_to_shape;
+
+    // TODO: check dimensions & attributes needed or default
+    void infer_shapes_Conv(onnx::NodeProto &node);
+    void infer_shapes_Relu(onnx::NodeProto &node);
+    void infer_shapes_MaxPool(onnx::NodeProto &node);
+    void infer_shapes_Add(onnx::NodeProto &node);
+    void infer_shapes_GlobalAveragePool(onnx::NodeProto &node);
+    void infer_shapes_Flatten(onnx::NodeProto &node);
+    void infer_shapes_Gemm(onnx::NodeProto &node);
+};

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -7,6 +7,10 @@
 #include <iostream>
 #include "onnx.proto3.pb.h"
 
-onnx::GraphProto read_onnx(const std::string &filename);
-
-void iterate_graph(const ::onnx::GraphProto &graph);
+onnx::ModelProto read_onnx(const std::string &filename);
+void print_dim(const ::onnx::TensorShapeProto_Dimension &dim);
+void print_val_info(const ::onnx::ValueInfoProto &info);
+void print_dims_vec(const std::vector<int64_t> &dims);
+std::string dims_vec_to_str(const std::vector<int64_t> &dims);
+void set_vec_to_shape(onnx::ValueInfoProto *val_info, const std::vector<int64_t> &dims);
+std::string string_trimmer(const std::string &inputString, const size_t maxLen);

--- a/src/InferShape.cpp
+++ b/src/InferShape.cpp
@@ -1,0 +1,373 @@
+#include <math.h>
+#include <iomanip>
+#include "InferShape.hpp"
+#include "utils.hpp"
+#include "AttrInfo.hpp"
+
+void InferShapeImpl::set_io_iniz_shape_to_map() {
+    for (auto input : this->graph.input()) {
+        auto shape = input.type().tensor_type().shape();
+        std::vector<int64_t> shape_vec = {};
+        for (int i = 0; i < shape.dim_size(); ++i) {
+            auto dim = shape.dim(i);
+            if (dim.has_dim_value()) {
+                shape_vec.emplace_back(dim.dim_value());
+            }
+        }
+        this->ndname_to_shape[input.name()] = shape_vec;
+    }
+
+    for (auto initializer : this->graph.initializer()) {
+        auto shape = initializer.dims();
+        std::vector<int64_t> shape_vec = {};
+        for (int i = 0; i < shape.size(); ++i) {
+            shape_vec.emplace_back(shape.Get(i));
+        }
+        this->ndname_to_shape[initializer.name()] = shape_vec;
+    }
+
+    for (auto output : this->graph.output()) {
+        auto shape = output.type().tensor_type().shape();
+        std::vector<int64_t> shape_vec = {};
+        for (int i = 0; i < shape.dim_size(); ++i) {
+            auto dim = shape.dim(i);
+            if (dim.has_dim_value()) {
+                shape_vec.emplace_back(dim.dim_value());
+            }
+        }
+        this->ndname_to_shape[output.name()] = shape_vec;
+    }
+}
+
+void InferShapeImpl::print_summary() {
+    std::cout << std::left << std::setw(INDENT) << "Name"
+              << std::left << std::setw(INDENT) << "Type"
+              << std::left << std::setw(INDENT) << "Input Shape"
+              << std::left << std::setw(INDENT) << "Output Shape" << '\n';
+    std::cout << std::string(INDENT * 4, '-') << '\n';
+
+    for (auto node : graph.node()) {
+        std::cout << std::left << std::setw(INDENT) << string_trimmer(node.name(), INDENT-5);
+
+        std::cout << std::left << std::setw(INDENT) << node.op_type();
+        std::cout << std::setw(INDENT) << dims_vec_to_str(this->get_ndname_to_shape()[node.input(0)]);
+        std::cout << std::setw(INDENT) << dims_vec_to_str(this->get_ndname_to_shape()[node.output(0)]);
+        std::cout << '\n';
+    }
+}
+
+void InferShapeImpl::infer_shapes_Conv(onnx::NodeProto &node) {
+    // get attributes (kernel_shape, strides, pads, dilations, group)
+    struct AttrInfo_Conv attr_info;
+    for (auto attr : node.attribute()) {
+        if (attr.name() == "kernel_shape") {
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.kernel_shape.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "strides") {
+            attr_info.strides.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.strides.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "pads") {
+            attr_info.pads.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.pads.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "dilations") {
+            attr_info.dilations.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.dilations.emplace_back(attr.ints(i));
+            }
+        }
+    }
+
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (auto ndinput : node.input()) {
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+            exit(1);
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+        }
+    }
+
+    // calculate output shape after convolution
+    auto input_shape = input_shapes[0];
+    auto weight_shape = input_shapes[1];
+    std::vector<int64_t> output_shape = {
+        input_shape[0], // batch size
+        weight_shape[0], // number of channels
+        (input_shape[2] + 2 * attr_info.pads[0] - attr_info.dilations[0] * (weight_shape[2] - 1) - 1) / attr_info.strides[0] + 1, // height
+        (input_shape[3] + 2 * attr_info.pads[1] - attr_info.dilations[1] * (weight_shape[3] - 1) - 1) / attr_info.strides[1] + 1 // width
+    };
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, output_shape);
+
+    this->ndname_to_shape[node.output(0)] = output_shape;
+}
+
+void InferShapeImpl::infer_shapes_Relu(onnx::NodeProto &node) {
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (auto ndinput : node.input()) {
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+        }
+    }
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, input_shapes[0]);
+
+    this->ndname_to_shape[node.output(0)] = input_shapes[0];
+}
+
+void InferShapeImpl::infer_shapes_MaxPool(onnx::NodeProto &node) {
+    struct AttrInfo_MaxPool attr_info;
+    for (auto attr : node.attribute()) {
+        // std::cout << "attr name: " << attr.name() << '\n';
+        if (attr.name() == "kernel_shape") { // required
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.kernel_shape.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "strides") {
+            attr_info.strides.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.strides.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "pads") {
+            attr_info.pads.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.pads.emplace_back(attr.ints(i));
+            }
+        }
+        else if (attr.name() == "ceil_mode") {
+            attr_info.ceil_mode = attr.i();
+            // std::cout << "ceil_mode: " << attr_info.ceil_mode << '\n';
+        }
+        else if (attr.name() == "dilations") {
+            attr_info.dilations.clear();
+            for (int i = 0; i < attr.ints_size(); ++i) {
+                attr_info.dilations.emplace_back(attr.ints(i));
+            }
+        }
+    }
+
+    // calculate output shape after maxpool
+    auto input_shape = this->get_ndname_to_shape()[node.input(0)];
+    std::vector<int64_t> output_shape = {
+        input_shape[0], // batch size
+        input_shape[1], // number of channels
+        (input_shape[2] + 2 * attr_info.pads[0] - attr_info.dilations[0] * (attr_info.kernel_shape[0] - 1) - 1) / attr_info.strides[0] + 1, // height
+        (input_shape[3] + 2 * attr_info.pads[1] - attr_info.dilations[1] * (attr_info.kernel_shape[1] - 1) - 1) / attr_info.strides[1] + 1 // width
+    };
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, output_shape);
+
+    this->ndname_to_shape[node.output(0)] = output_shape;
+}
+
+void InferShapeImpl::infer_shapes_Add(onnx::NodeProto &node) {
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (auto ndinput : node.input()) {
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+        }
+    }
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, input_shapes[0]);
+
+    this->ndname_to_shape[node.output(0)] = input_shapes[0];
+}
+
+void InferShapeImpl::infer_shapes_GlobalAveragePool(onnx::NodeProto &node) {
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (auto ndinput : node.input()) {
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+        }
+    }
+
+    // calculate output shape after globalaveragepool
+    std::vector<int64_t> output_shape = {
+        input_shapes[0][0], // batch size
+        input_shapes[0][1], // number of channels
+        1, // height
+        1 // width
+    };
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, output_shape);
+
+    this->ndname_to_shape[node.output(0)] = output_shape;
+}
+
+void InferShapeImpl::infer_shapes_Flatten(onnx::NodeProto &node) {
+    // for (auto attr : node.attribute()) {
+    //     if (attr.name() == "axis") {
+    //         std::cout << "axis: " << attr.i() << '\n';
+    //     }
+    // }
+
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (auto ndinput : node.input()) {
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+        }
+    }
+
+    // calculate output shape after flatten
+    std::vector<int64_t> output_shape;
+    int64_t flatten_dim = 1;
+    for (size_t i = 2; i < input_shapes[0].size(); ++i) {
+        flatten_dim *= input_shapes[0][i];
+    }
+
+    if (flatten_dim == 1) {
+        output_shape = {
+            input_shapes[0][0], // batch size
+            input_shapes[0][1] // number of channels
+        };
+    }
+    else {
+        output_shape = {
+            input_shapes[0][0], // batch size
+            input_shapes[0][1], // number of channels
+            flatten_dim // flatten_dim
+        };
+    }
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, output_shape);
+
+    this->ndname_to_shape[node.output(0)] = output_shape;
+}
+
+void InferShapeImpl::infer_shapes_Gemm(onnx::NodeProto &node) {
+    // get attributes
+    AttrInfo_Gemm attr_info;
+    for (auto attr : node.attribute()) {
+        if (attr.name() == "transA") {
+            if (attr.i() == 1) attr_info.transA = true;
+        }
+        else if (attr.name() == "transB") {
+            if (attr.i() == 1) attr_info.transB = true;
+        }
+    }
+
+    // get node input shapes
+    std::vector<std::vector<int64_t>> input_shapes;
+    for (size_t num = 0; num < 2; ++num) {
+        auto ndinput = node.input(num);
+        if (this->get_ndname_to_shape().find(ndinput) == this->get_ndname_to_shape().end()) {
+            std::cerr << "Error: " << ndinput << " not found in ndname_to_shape\n";
+            return;
+        }
+        else {
+            // get shape from ndname_to_shape
+            input_shapes.emplace_back(this->get_ndname_to_shape()[ndinput]);
+            if (num == 0 && attr_info.transA) {
+                std::reverse(input_shapes[num].begin(), input_shapes[num].end());
+            }
+            else if (num == 1 && attr_info.transB) {
+                std::reverse(input_shapes[num].begin(), input_shapes[num].end());
+            }
+        }
+    }
+
+    // calculate output shape after gemm
+    // [M, K] * [K, N] = [M, N]
+    std::vector<int64_t> output_shape;
+    output_shape = {
+        input_shapes[0][0],
+        input_shapes[1][1]
+    };
+
+    // set value_info and update ndname_to_shape
+    onnx::ValueInfoProto *val_info = this->graph.add_value_info();
+    val_info->set_name(node.name());
+    set_vec_to_shape(val_info, output_shape);
+
+    this->ndname_to_shape[node.output(0)] = output_shape;
+}
+
+void InferShapeImpl::infer_shapes() {
+    this->set_io_iniz_shape_to_map();
+
+    // infer shape for each node and store to value_info
+    for (auto node : graph.node()) {
+        // std::cout << "Node: " << node.name() << '\n';
+        if (node.op_type() == "Conv") {
+            this->infer_shapes_Conv(node);
+        }
+        else if (node.op_type() == "Relu") {
+            this->infer_shapes_Relu(node);
+        }
+        else if (node.op_type() == "MaxPool") {
+            this->infer_shapes_MaxPool(node);
+        }
+        else if (node.op_type() == "Add") {
+            this->infer_shapes_Add(node);
+        }
+        else if (node.op_type() == "GlobalAveragePool") {
+            this->infer_shapes_GlobalAveragePool(node);
+        }
+        else if (node.op_type() == "Flatten") {
+            this->infer_shapes_Flatten(node);
+        }
+        else if (node.op_type() == "Gemm") {
+            this->infer_shapes_Gemm(node);
+        }
+        else {
+            std::cerr << "Error: " << node.op_type() << " not supported now\n";
+            return;
+        }
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,29 +1,24 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "utils.hpp"
+#include "InferShape.hpp"
 
-int main(int argc, char **argv) {
-  if (argc != 2) {
-    std::cerr << "Usage: " << argv[0] << " <onnx-model-path>\n";
-    return 1;
-  }
-
-  // onnx::ModelProto model = read_onnx(argv[1]);
-  // onnx::GraphProto graph = model.graph();
-  // iterate_graph(graph);
-  iterate_graph(read_onnx(argv[1]));
-
-  return 0;
-}
+namespace py = pybind11;
 
 PYBIND11_MODULE(_onnxinfo, m) {
   m.doc() = "pybind11 onnxinfo module"; // optional module docstring
 
   m.def("read_onnx", &read_onnx, "A C++ function that read ONNX model");
-  m.def("iterate_graph", &iterate_graph, "A C++ function that iterate ONNX graph");
+  // m.def("iterate_graph", &iterate_graph, "A C++ function that iterate ONNX graph");
 
-  // pybind11::class_<onnx::ModelProto>(m, "ModelProto")
-  //   .def(pybind11::init())
-  //   .def_readonly("graph", &onnx::ModelProto::graph);
-  pybind11::class_<onnx::GraphProto>(m, "GraphProto");
+  py::class_<InferShapeImpl>(m, "InferShapeImpl")
+    .def(py::init<const onnx::GraphProto &>())
+    .def("set_io_iniz_shape_to_map", &InferShapeImpl::set_io_iniz_shape_to_map)
+    .def("infer_shapes", &InferShapeImpl::infer_shapes)
+    .def("print_summary", &InferShapeImpl::print_summary)
+    .def("get_ndname_to_shape", &InferShapeImpl::get_ndname_to_shape);
+
+  py::class_<onnx::ModelProto>(m, "ModelProto")
+    .def("graph", &onnx::ModelProto::graph);
+  py::class_<onnx::GraphProto>(m, "GraphProto");
 }

--- a/tests/test_onnxinfo.py
+++ b/tests/test_onnxinfo.py
@@ -9,9 +9,19 @@ def test_read_onnx():
     info = _onnxinfo.read_onnx('models/resnet18_Opset16.onnx')
     assert info is not None
 
-def test_iterate_onnx():
+def test_infer_shape():
+    model = _onnxinfo.read_onnx('models/resnet18_Opset16.onnx')
+    target = _onnxinfo.InferShapeImpl(model.graph())
+    old_size = len(target.get_ndname_to_shape())
+    target.infer_shapes()
+    new_size = len(target.get_ndname_to_shape())
+    assert new_size > old_size
+
+def test_print_summary():
     try:
-        graph = _onnxinfo.read_onnx('models/resnet18_Opset16.onnx')
-        _onnxinfo.iterate_graph(graph)
+        model = _onnxinfo.read_onnx('models/resnet18_Opset16.onnx')
+        target = _onnxinfo.InferShapeImpl(model.graph())
+        target.infer_shapes()
+        target.print_summary()
     except:
         pytest.fail("iterate_graph failed")


### PR DESCRIPTION
Supported node operator types right now
* Conv
* Relu
* MaxPool
* Add
* GlobalAveragePool
* Flatten
* Gemm

This is related to https://github.com/ExplorerRay/onnxinfo/issues/16